### PR TITLE
Convert "String" to "Hex" (kind of)

### DIFF
--- a/src/App/Sources/Crypto/Hmac.elm
+++ b/src/App/Sources/Crypto/Hmac.elm
@@ -7,9 +7,17 @@ module Sources.Crypto.Hmac exposing (encrypt64, encrypt128)
 import Bitwise
 import Char
 import Debug
+import Hex
 import Sources.Crypto.Hex exposing (hexStringToUtf8String)
 import Sources.Crypto.Types exposing (..)
 
+toSHAHex : String -> String
+toSHAHex input =
+    input
+        |> String.toList
+        |> List.map Char.toCode
+        |> List.map Hex.toString
+        |> String.concat
 
 {-| HMAC encryption for hashing algorithms with a `blockSize` of 64.
 These include: SHA-0, SHA-1, SHA-224, SHA-256, MD5, etc.
@@ -75,6 +83,5 @@ encrypt blockSize hasher message key =
         message
             |> String.append partA
             |> hasher
-            |> hexStringToUtf8String
-            |> String.append partB
+            |> String.append("0x" ++ toSHAHex(partB))
             |> hasher


### PR DESCRIPTION
Hey! I think I figured out the root cause of this. This PR fixes the two `SHA256` test cases.

So, it seems that the `SHA` lib, when computing the SHA sum, takes your UTF8 string, and returns the hex encoding of the result as a _string_ which is super misleading haha.

This is okay though: that same library will treat any string that starts with `0x` as a hex-encoded string, so we can just convert the normal UTF8 string that is `partB` to a hex-encoded string, and prepend `0x` to it. This gives the desired result.

I didn't try to get the MD5 test passing, but I suspect it's a similar issue.

I ended up figuring this out by doing each step of the HMAC algorithm in Go, and printing out the output after each step. You can see at https://play.golang.org/p/oFbIR8kLNN that the previous approach was returning the value printed out at line 15 (if that helps at all, that Go code is really messy).

Also I'm sure there's a way better to write this code, I'm just really really bad at Elm/functional programming in general haha.